### PR TITLE
Create jakarta artifact replacing javax.json with jakarta.json

### DIFF
--- a/jsr-353/pom.xml
+++ b/jsr-353/pom.xml
@@ -53,6 +53,96 @@ working with JSR-353 (JSON-P) node types via data-binding
         <groupId>org.moditect</groupId>
         <artifactId>moditect-maven-plugin</artifactId>
       </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>jakarta</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>jakarta</shadedClassifierName>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <artifactSet>
+                <includes>
+                  <include>${project.groupId}:${project.artifactId}</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>${project.groupId}:${project.artifactId}</artifact>
+                  <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>javax.json</pattern>
+                  <shadedPattern>jakarta.json</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/MANIFEST.MF</resource>
+                  <file>${project.build.directory}/jakarta/MANIFEST.MF</file>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>io.yupiik.maven</groupId>
+            <artifactId>maven-shade-transformers</artifactId>
+            <version>0.0.1</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <!-- Jakarta bundle fix - nb place last for execution order on package phase
+      @gedmarc 20210222-->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default_bundle</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${project.build.directory}/javax</manifestLocation>
+              <packaging>jar</packaging>
+              <instructions>
+                <_nouses>false</_nouses>
+              </instructions>
+            </configuration>
+          </execution>
+          <execution>
+            <id>bundle_jakarta_manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${project.build.directory}/jakarta</manifestLocation>
+              <classifier>jakarta</classifier>
+              <packaging>jar</packaging>
+              <instructions>
+                <Import-Package>jakarta.json;version="[3.0,4)",!javax.json,*</Import-Package>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Fixes #6.

This is an alternative solution to the problem, using postprocessing of the class files using the maven-shade-plugin as applied by jackson-jaxrs-providers.