### PR TITLE
[jsonp] fix issue with big int handing

### DIFF
--- a/jakarta-jsonp/src/main/java/com/fasterxml/jackson/datatype/jsonp/JsonValueDeserializer.java
+++ b/jakarta-jsonp/src/main/java/com/fasterxml/jackson/datatype/jsonp/JsonValueDeserializer.java
@@ -230,16 +230,16 @@ public class JsonValueDeserializer extends StdDeserializer<JsonValue>
                         return b.add(p.getBigIntegerValue()).build().get(0);
                 }
             }
-    case VALUE_STRING:
-        return _builderFactory.createArrayBuilder().add(p.getText()).build().get(0);
-    default: // errors, should never get here
+        case VALUE_STRING:
+            return _builderFactory.createArrayBuilder().add(p.getText()).build().get(0);
+        default: // errors, should never get here
 //        case END_ARRAY:
 //        case END_OBJECT:
 //        case FIELD_NAME:
 //        case NOT_AVAILABLE:
 //        case START_ARRAY:
 //        case START_OBJECT:
-        return (JsonValue) ctxt.handleUnexpectedToken(getValueType(ctxt), p);
+            return (JsonValue) ctxt.handleUnexpectedToken(getValueType(ctxt), p);
         }
     }
 }

--- a/jakarta-jsonp/src/main/java/com/fasterxml/jackson/datatype/jsonp/JsonValueDeserializer.java
+++ b/jakarta-jsonp/src/main/java/com/fasterxml/jackson/datatype/jsonp/JsonValueDeserializer.java
@@ -5,7 +5,6 @@ import jakarta.json.*;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonParser.NumberType;
 import com.fasterxml.jackson.core.JsonToken;
 
 import com.fasterxml.jackson.databind.DeserializationContext;

--- a/jakarta-jsonp/src/main/java/com/fasterxml/jackson/datatype/jsonp/JsonValueDeserializer.java
+++ b/jakarta-jsonp/src/main/java/com/fasterxml/jackson/datatype/jsonp/JsonValueDeserializer.java
@@ -115,11 +115,7 @@ public class JsonValueDeserializer extends StdDeserializer<JsonValue>
                     b.addNull(name);
                     break;
                 case VALUE_NUMBER_FLOAT:
-                    if (p.getNumberType() == NumberType.BIG_DECIMAL) {
-                        b.add(name, p.getDecimalValue());
-                    } else {
-                        b.add(name, p.getDoubleValue());
-                    }
+                    b.add(name, p.getDecimalValue());
                     break;
                 case VALUE_NUMBER_INT:
                     // very cumbersome... but has to be done
@@ -177,11 +173,7 @@ public class JsonValueDeserializer extends StdDeserializer<JsonValue>
                     b.addNull();
                     break;
                 case VALUE_NUMBER_FLOAT:
-                    if (p.getNumberType() == NumberType.BIG_DECIMAL) {
-                        b.add(p.getDecimalValue());
-                    } else {
-                        b.add(p.getDoubleValue());
-                    }
+                    b.add(p.getDecimalValue());
                     break;
                 case VALUE_NUMBER_INT:
                     // very cumbersome... but has to be done
@@ -224,13 +216,10 @@ public class JsonValueDeserializer extends StdDeserializer<JsonValue>
             // very cumbersome... but has to be done
             {
                 JsonArrayBuilder b = _builderFactory.createArrayBuilder();
-                if (p.getNumberType() == NumberType.BIG_DECIMAL) {
-                    return b.add(p.getDecimalValue()).build().get(0);
-                }
-                return b.add(p.getDoubleValue()).build().get(0);
+                return b.add(p.getDecimalValue()).build().get(0);
             }
-	case VALUE_NUMBER_INT:
-                // very cumbersome... but has to be done
+        case VALUE_NUMBER_INT:
+            // very cumbersome... but has to be done
             {
                 JsonArrayBuilder b = _builderFactory.createArrayBuilder();
                 switch (p.getNumberType()) {
@@ -242,16 +231,16 @@ public class JsonValueDeserializer extends StdDeserializer<JsonValue>
                         return b.add(p.getBigIntegerValue()).build().get(0);
                 }
             }
-	case VALUE_STRING:
-	    return _builderFactory.createArrayBuilder().add(p.getText()).build().get(0);
-	default: // errors, should never get here
+    case VALUE_STRING:
+        return _builderFactory.createArrayBuilder().add(p.getText()).build().get(0);
+    default: // errors, should never get here
 //        case END_ARRAY:
 //        case END_OBJECT:
 //        case FIELD_NAME:
 //        case NOT_AVAILABLE:
 //        case START_ARRAY:
 //        case START_OBJECT:
-	    return (JsonValue) ctxt.handleUnexpectedToken(getValueType(ctxt), p);
+        return (JsonValue) ctxt.handleUnexpectedToken(getValueType(ctxt), p);
         }
     }
 }

--- a/jakarta-jsonp/src/test/java/com/fasterxml/jackson/datatype/jsonp/JsonValueDeserializationTest.java
+++ b/jakarta-jsonp/src/test/java/com/fasterxml/jackson/datatype/jsonp/JsonValueDeserializationTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.beans.ConstructorProperties;
+import java.math.BigDecimal;
 
 public class JsonValueDeserializationTest extends TestBase
 {
@@ -133,5 +134,24 @@ public class JsonValueDeserializationTest extends TestBase
         ObjectImpl ob2 = MAPPER.readValue("{\"obj2\":null}", ObjectImpl.class);
         assertNull(ob2.obj1);
         assertSame(JsonValue.NULL, ob2.obj2);
+    }
+
+    public void testBigInteger() throws Exception
+    {
+        final String JSON = "[2e308]";
+        JsonValue v = MAPPER.readValue(JSON, JsonValue.class);
+        assertTrue(v instanceof JsonArray);
+        JsonArray a = (JsonArray) v;
+        assertEquals(1, a.size());
+        assertTrue(a.get(0) instanceof JsonNumber);
+        assertEquals(new BigDecimal("2e308").toBigInteger(), ((JsonNumber) a.get(0)).bigIntegerValue());
+
+
+        // also, should work with explicit type
+        JsonArray array = MAPPER.readValue(JSON, JsonArray.class);
+        assertEquals(1, array.size());
+
+        // and round-tripping ought to be ok:
+        assertEquals(JSON, serializeAsString(v));
     }
 }

--- a/jakarta-jsonp/src/test/java/com/fasterxml/jackson/datatype/jsonp/JsonValueDeserializationTest.java
+++ b/jakarta-jsonp/src/test/java/com/fasterxml/jackson/datatype/jsonp/JsonValueDeserializationTest.java
@@ -152,6 +152,6 @@ public class JsonValueDeserializationTest extends TestBase
         assertEquals(1, array.size());
 
         // and round-tripping ought to be ok:
-        assertEquals(JSON, serializeAsString(v));
+        assertEquals("[2E+308]", serializeAsString(v));
     }
 }


### PR DESCRIPTION
* I added the test case and it failed
* I debugged the code and found that org.glassfish.json.JsonNumberImpl uses BigDecimals under the hood so there is no perf benefit to trying to use doubles (and the risk with the doubles losing precision and truncating big numbers)
* what happened in my test is the Jackson code uses toDouble and that evals to Double.Infinity and things get worse from there