### PR TITLE
[json-org] fix issue with parsing big numbers

### DIFF
--- a/json-org/src/main/java/com/fasterxml/jackson/datatype/jsonorg/JSONArrayDeserializer.java
+++ b/json-org/src/main/java/com/fasterxml/jackson/datatype/jsonorg/JSONArrayDeserializer.java
@@ -66,7 +66,7 @@ public class JSONArrayDeserializer extends StdDeserializer<JSONArray>
                 array.put(p.getNumberValue());
                 continue;
             case VALUE_NUMBER_FLOAT:
-                array.put(p.getNumberValue());
+                array.put(p.getDecimalValue());
                 continue;
             case VALUE_EMBEDDED_OBJECT:
                 array.put(p.getEmbeddedObject());

--- a/json-org/src/main/java/com/fasterxml/jackson/datatype/jsonorg/JSONObjectDeserializer.java
+++ b/json-org/src/main/java/com/fasterxml/jackson/datatype/jsonorg/JSONObjectDeserializer.java
@@ -63,7 +63,7 @@ public class JSONObjectDeserializer extends StdDeserializer<JSONObject>
                     ob.put(fieldName, p.getNumberValue());
                     continue;
                 case VALUE_NUMBER_FLOAT:
-                    ob.put(fieldName, p.getNumberValue());
+                    ob.put(fieldName, p.getDecimalValue());
                     continue;
                 case VALUE_EMBEDDED_OBJECT:
                     ob.put(fieldName, p.getEmbeddedObject());

--- a/json-org/src/test/java/com/fasterxml/jackson/datatype/jsonorg/SimpleReadTest.java
+++ b/json-org/src/test/java/com/fasterxml/jackson/datatype/jsonorg/SimpleReadTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.*;
 
 import org.json.*;
 
-import com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule;
+import java.math.BigDecimal;
 
 public class SimpleReadTest extends ModuleTestBase
 {
@@ -45,5 +45,24 @@ public class SimpleReadTest extends ModuleTestBase
         assertEquals(13, ob.getInt("a"));
         JSONArray array2 = array.getJSONArray(6);
         assertEquals(0, array2.length());
+    }
+
+    public void testBigInteger() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JsonOrgModule());
+
+        JSONObject val = mapper.readValue("{\"val\":2e308}", JSONObject.class);
+        assertEquals(new BigDecimal("2e308").toBigInteger(), val.getBigInteger("val"));
+    }
+
+    public void testBigIntegerArray() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JsonOrgModule());
+
+        JSONArray array = mapper.readValue("[2e308]", JSONArray.class);
+        assertEquals(1, array.length());
+        assertEquals(new BigDecimal("2e308").toBigInteger(), array.getBigInteger(0));
     }
 }


### PR DESCRIPTION
* equivalent of https://github.com/FasterXML/jackson-datatypes-misc/pull/31
* same issue with BigInt being parsed as a Double and Double cannot a number as big as 2e308 and treats it as Double.Infinity and things get worse from there