### PR TITLE
jakarta.json-api 2.1.1

### DIFF
--- a/jakarta-jsonp/pom.xml
+++ b/jakarta-jsonp/pom.xml
@@ -43,9 +43,9 @@ working with JSON-P (JSON Processing) node types (new Jakarta flavor) via data-b
 
     <!-- and for tests can use the CI -->
     <dependency>
-        <groupId>org.glassfish</groupId>
-        <artifactId>jakarta.json</artifactId>
-        <version>2.1.1</version>
+        <groupId>org.eclipse.parsson</groupId>
+        <artifactId>parsson</artifactId>
+        <version>1.1.1</version>
         <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jakarta-jsonp/pom.xml
+++ b/jakarta-jsonp/pom.xml
@@ -38,14 +38,14 @@ working with JSON-P (JSON Processing) node types (new Jakarta flavor) via data-b
     <dependency>
         <groupId>jakarta.json</groupId>
         <artifactId>jakarta.json-api</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.1</version>
     </dependency>
 
     <!-- and for tests can use the CI -->
     <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>jakarta.json</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.1</version>
         <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
* possibly a good idea to upgrade the dependency occasionally
* seems like https://github.com/eclipse-ee4j/parsson is now the default implementation
* I couldn't find much documentation online about this but glassfish jar doesn't seem to work
* https://jakarta.ee/specifications/jsonp/2.1/ lists only Parsson as a compatible implementation for that version of the API