### PR TITLE
Fix class path scaning on each deserialization

### DIFF
--- a/jakarta-jsonp/src/main/java/com/fasterxml/jackson/datatype/jsonp/JsonPatchDeserializer.java
+++ b/jakarta-jsonp/src/main/java/com/fasterxml/jackson/datatype/jsonp/JsonPatchDeserializer.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.type.LogicalType;
 
-import jakarta.json.Json;
 import jakarta.json.JsonPatch;
+import jakarta.json.spi.JsonProvider;
 
 public class JsonPatchDeserializer extends StdDeserializer<JsonPatch>
 {
@@ -30,6 +30,8 @@ public class JsonPatchDeserializer extends StdDeserializer<JsonPatch>
     public JsonPatch deserialize(JsonParser p, DeserializationContext ctxt)
         throws IOException
     {
-        return Json.createPatch(jsonValueDeser._deserializeArray(p, ctxt));
+        return provider.createPatch(jsonValueDeser._deserializeArray(p, ctxt));
     }
+
+    private final static JsonProvider provider = JsonProvider.provider();
 }

--- a/jsr-353/src/main/java/com/fasterxml/jackson/datatype/jsr353/JsonPatchDeserializer.java
+++ b/jsr-353/src/main/java/com/fasterxml/jackson/datatype/jsr353/JsonPatchDeserializer.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.type.LogicalType;
 
-import javax.json.Json;
 import javax.json.JsonPatch;
+import javax.json.spi.JsonProvider;
 import java.io.IOException;
 
 public class JsonPatchDeserializer extends StdDeserializer<JsonPatch> {
@@ -31,6 +31,8 @@ public class JsonPatchDeserializer extends StdDeserializer<JsonPatch> {
             throw InvalidFormatException.from(p, "JSON patch has to be an array of objects", p.getText(),
                 handledType());
         }
-        return Json.createPatch(jsonValueDeser._deserializeArray(p, ctxt));
+        return provider.createPatch(jsonValueDeser._deserializeArray(p, ctxt));
     }
+
+    private final static JsonProvider provider = JsonProvider.provider();
 }


### PR DESCRIPTION
Hello, there is a problem with Json.createPatch(), it calls JsonProvider.provider() on each call.

Accordingly to java doc of provider() method: "Creates a JSON provider object. The provider is loaded using the ServiceLoader.load(Class) method. If there are no available service providers, this method returns the default service provider. Users are recommended to cache the result of this method.".

Let's cache it as static variable.

We faced with a lot of CPU issues because of this method.

What do you think about it?