### PR TITLE
add number tests

### DIFF
--- a/json-org/src/test/java/com/fasterxml/jackson/datatype/jsonorg/SimpleReadTest.java
+++ b/json-org/src/test/java/com/fasterxml/jackson/datatype/jsonorg/SimpleReadTest.java
@@ -47,6 +47,16 @@ public class SimpleReadTest extends ModuleTestBase
         assertEquals(0, array2.length());
     }
 
+    public void testDouble() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JsonOrgModule());
+
+        JSONObject val = mapper.readValue("{\"val\":0.5}", JSONObject.class);
+        assertEquals(0.5d, val.getDouble("val"));
+        assertEquals(new BigDecimal(0.5d), val.get("val"));
+    }
+
     public void testBigInteger() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();

--- a/jsr-353/src/test/java/com/fasterxml/jackson/datatype/jsr353/JsonValueDeserializationTest.java
+++ b/jsr-353/src/test/java/com/fasterxml/jackson/datatype/jsr353/JsonValueDeserializationTest.java
@@ -155,4 +155,13 @@ public class JsonValueDeserializationTest extends TestBase
         // and round-tripping ought to be ok:
         assertEquals("[2E+308]", serializeAsString(v));
     }
+
+    public void testDouble() throws Exception
+    {
+        JsonValue val = MAPPER.readValue("{\"val\":0.5}", JsonValue.class);
+        JsonObject jsonObject = val.asJsonObject();
+        JsonNumber jsonNumber = jsonObject.getJsonNumber("val");
+        assertEquals(0.5d, jsonNumber.doubleValue());
+        assertEquals(new BigDecimal(0.5d), jsonNumber.numberValue());
+    }
 }


### PR DESCRIPTION
* relates to conversation starting at https://github.com/FasterXML/jackson-datatypes-misc/pull/32#issuecomment-1664854300
* the number behaviour changed in v2.15.0
* both jsr-353 and json-org provide getters on their Json Value APIs that allow users to choose what number format they want - users have this control
* users who insist on using the APIs that return `java.lang.Number` will see differences after v2.15. They get a BigDecimal instead of a double. This is a little unfortunate but the changes help users who need us to retain the precision of big numbers.
* I would prefer not to make big changes and not to revert the 2.15 changes. I think it is better to play it by ear - to see just how many people complain and get their reasons why they can't make small changes to their own code to react to the jackson change. 