### PR TITLE
Port `JsonPatch` START_ARRAY check from jsr-353 module

### DIFF
--- a/jakarta-jsonp/src/main/java/tools/jackson/datatype/jsonp/JsonPatchDeserializer.java
+++ b/jakarta-jsonp/src/main/java/tools/jackson/datatype/jsonp/JsonPatchDeserializer.java
@@ -2,8 +2,10 @@ package tools.jackson.datatype.jsonp;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.exc.InvalidFormatException;
 import tools.jackson.databind.type.LogicalType;
 
 import jakarta.json.JsonPatch;
@@ -27,6 +29,13 @@ public class JsonPatchDeserializer extends StdDeserializer<JsonPatch>
     public JsonPatch deserialize(JsonParser p, DeserializationContext ctxt)
         throws JacksonException
     {
+        // 09-Sep-2026, pjfanning: [datatypes-misc#92] Verify it IS an Array; otherwise
+        //    `_deserializeArray()` reads past the end of the document and fails with
+        //    a bare NPE on the resulting `null` token
+        if (p.currentToken() != JsonToken.START_ARRAY) {
+            throw InvalidFormatException.from(p, "JSON patch has to be an array of objects", p.getString(),
+                handledType());
+        }
         return provider.createPatch(jsonValueDeser._deserializeArray(p, ctxt));
     }
 

--- a/jakarta-jsonp/src/test/java/tools/jackson/datatype/jsonp/JsonPatchDeserializationTest.java
+++ b/jakarta-jsonp/src/test/java/tools/jackson/datatype/jsonp/JsonPatchDeserializationTest.java
@@ -1,6 +1,7 @@
 package tools.jackson.datatype.jsonp;
 
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.exc.InvalidFormatException;
 
 import jakarta.json.*;
 
@@ -14,6 +15,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class JsonPatchDeserializationTest extends TestBase {
 
     private static final ObjectMapper MAPPER = newMapper();
+
+    private static final String EXPECTED_MESSAGE = "JSON patch has to be an array of objects";
 
     @Test
     public void testDeserializationAndPatching() throws Exception {
@@ -49,6 +52,31 @@ public class JsonPatchDeserializationTest extends TestBase {
         final JsonStructure patchedPersonJson = jsonPatch.apply(personJson);
         final Person patchedPerson = MAPPER.convertValue(patchedPersonJson, Person.class);
         assertThat(patchedPerson).isEqualTo(new Person("Json", "Smith"));
+    }
+
+    @Test
+    public void testObjectDeserializationAndPatching() {
+        final String json = a2q("{'op':'replace','path':'/name','value':'Json'}");
+
+        final InvalidFormatException ex = assertThrows(InvalidFormatException.class,
+                () -> MAPPER.readValue(json, JsonPatch.class));
+        assertThat(ex.getMessage()).contains(EXPECTED_MESSAGE);
+    }
+
+    @Test
+    public void testScalarDeserializationAndPatching() {
+        final String json = a2q("'op'");
+
+        final InvalidFormatException ex = assertThrows(InvalidFormatException.class,
+                () -> MAPPER.readValue(json, JsonPatch.class));
+        assertThat(ex.getMessage()).contains(EXPECTED_MESSAGE);
+    }
+
+    @Test
+    public void testNumberDeserializationAndPatching() {
+        final InvalidFormatException ex = assertThrows(InvalidFormatException.class,
+                () -> MAPPER.readValue("42", JsonPatch.class));
+        assertThat(ex.getMessage()).contains(EXPECTED_MESSAGE);
     }
 
     static class Person {

--- a/jakarta-jsonp/src/test/java/tools/jackson/datatype/jsonp/TestBase.java
+++ b/jakarta-jsonp/src/test/java/tools/jackson/datatype/jsonp/TestBase.java
@@ -49,4 +49,8 @@ public abstract class TestBase
     protected JsonObjectBuilder objectBuilder() {
         return MODULE._builderFactory.createObjectBuilder();
     }
+
+    protected static String a2q(String json) {
+        return json.replace("'", "\"");
+    }
 }

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -15,7 +15,8 @@ Modules:
 
 3.3.0 (not yet released)
 
-No changes since 3.2
+#92: (jakarta-jsonp) `JsonPatch` deserialization throws `NullPointerException`
+  for non-Array input
 
 3.2.2 (14-Aug-2026)
 


### PR DESCRIPTION
### Problem

Commit 59447f3 ("Fixes wrt [core#1378]") added a `START_ARRAY` guard — plus two tests — to `jsr-353`'s `JsonPatchDeserializer`, but the `jakarta-jsonp` copy of the same class was never updated. The two modules have drifted.

Without the guard, `_deserializeArray()` calls `nextToken()` past the end of the document and switches on the resulting `null` token, so non-Array input fails with a bare NPE:

| input read as `JsonPatch` | jsr-353 | jakarta-jsonp |
| --- | --- | --- |
| `"op"` | `InvalidFormatException` | `NullPointerException: Cannot invoke "tools.jackson.core.JsonToken.ordinal()" because "t" is null` |
| `42` | `InvalidFormatException` | `NullPointerException` |

### Fix

Port the guard verbatim from the jsr-353 twin, so both modules report the same `InvalidFormatException: JSON patch has to be an array of objects`.

### Tests

Brings over `testObjectDeserializationAndPatching` and `testScalarDeserializationAndPatching` from the jsr-353 test, plus one for numeric input. Adds the standard `a2q()` helper to `TestBase` for the new test content.

`jakarta-jsonp` suite: 26 tests, all green.