### PR TITLE
Fix `MonetaMoneyModule.getModuleName()` returning "JavaxMoneyModule"

### DIFF
--- a/moneta/src/main/java/tools/jackson/datatype/moneta/MonetaMoneyModule.java
+++ b/moneta/src/main/java/tools/jackson/datatype/moneta/MonetaMoneyModule.java
@@ -51,7 +51,7 @@ public final class MonetaMoneyModule extends JacksonModule
 
     @Override
     public String getModuleName() {
-        return JavaxMoneyModule.class.getSimpleName();
+        return MonetaMoneyModule.class.getSimpleName();
     }
 
     @Override

--- a/moneta/src/test/java/tools/jackson/datatype/moneta/ModuleNameTest.java
+++ b/moneta/src/test/java/tools/jackson/datatype/moneta/ModuleNameTest.java
@@ -1,0 +1,27 @@
+package tools.jackson.datatype.moneta;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.datatype.javax.money.JavaxMoneyModule;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ModuleNameTest
+{
+    @Test
+    public void testModuleName() {
+        assertEquals("MonetaMoneyModule", new MonetaMoneyModule().getModuleName());
+    }
+
+    @Test
+    public void testNameDiffersFromBaseModule() {
+        assertNotEquals(new JavaxMoneyModule().getModuleName(),
+                new MonetaMoneyModule().getModuleName());
+    }
+
+    // Base module keeps its own (correct) name
+    @Test
+    public void testBaseModuleName() {
+        assertEquals("JavaxMoneyModule", new JavaxMoneyModule().getModuleName());
+    }
+}

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -15,7 +15,7 @@ Modules:
 
 3.3.0 (not yet released)
 
-No changes since 3.2
+#93: (moneta) `MonetaMoneyModule.getModuleName()` returns "JavaxMoneyModule"
 
 3.2.2 (14-Aug-2026)
 


### PR DESCRIPTION
### Problem

Copy-paste slip in `MonetaMoneyModule`:

```java
@Override
public String getModuleName() {
    return JavaxMoneyModule.class.getSimpleName();   // -> "JavaxMoneyModule"
}
```

So the module reports itself under the base module's name:

```
new MonetaMoneyModule().getModuleName()  ->  "JavaxMoneyModule"
new JavaxMoneyModule().getModuleName()   ->  "JavaxMoneyModule"
```

Registration itself is fine — `getRegistrationId()` correctly resolves to `tools.jackson.datatype.moneta.MonetaMoneyModule`, so there is no duplicate-registration collision between the two modules — but the name is wrong everywhere it gets reported.

### Fix

Return `MonetaMoneyModule.class.getSimpleName()`.

### Tests

New `ModuleNameTest`: asserts the moneta module's own name, that it differs from the base module's, and that `JavaxMoneyModule` keeps its (already correct) name.

`javax-money` 135 tests and `moneta` 140 tests all green.