### PR TITLE
Support embedded binary in Arrays, as already done for Objects

### DIFF
--- a/jakarta-jsonp/src/main/java/tools/jackson/datatype/jsonp/JsonValueDeserializer.java
+++ b/jakarta-jsonp/src/main/java/tools/jackson/datatype/jsonp/JsonValueDeserializer.java
@@ -187,6 +187,16 @@ public class JsonValueDeserializer extends StdDeserializer<JsonValue>
                 case VALUE_STRING:
                     b.add(p.getString());
                     break;
+                case VALUE_EMBEDDED_OBJECT: {
+                    // 09-Sep-2026, pjfanning: as with Object values above, support
+                    //   binary data as Base64 encoded text
+                    Object ob = p.getEmbeddedObject();
+                    if (ob instanceof byte[]) {
+                        String b64 = ctxt.getBase64Variant().encode((byte[]) ob, false);
+                        b.add(b64);
+                        break;
+                    }
+                }
                 default:
                     return (JsonArray) ctxt.handleUnexpectedToken(getValueType(ctxt), p);
             }

--- a/jakarta-jsonp/src/test/java/tools/jackson/datatype/jsonp/EmbeddedBinaryTest.java
+++ b/jakarta-jsonp/src/test/java/tools/jackson/datatype/jsonp/EmbeddedBinaryTest.java
@@ -1,0 +1,69 @@
+package tools.jackson.datatype.jsonp;
+
+import java.util.Collections;
+
+import jakarta.json.*;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for binary (byte[]) content embedded in the token stream, which is
+ * exposed as Base64 encoded text (see [issue#5]). Verifies Array and Object
+ * positions behave the same way.
+ */
+public class EmbeddedBinaryTest extends TestBase
+{
+    private final ObjectMapper MAPPER = newMapper();
+
+    // 3 bytes that Base64-encode to "AQID"
+    private final static byte[] BINARY = new byte[] { 1, 2, 3 };
+
+    private final static String BINARY_B64 = "AQID";
+
+    @Test
+    public void testBinaryAsObjectValue() throws Exception
+    {
+        JsonValue v = MAPPER.convertValue(Collections.singletonMap("k", BINARY), JsonValue.class);
+        assertEquals(JsonValue.ValueType.OBJECT, v.getValueType());
+        assertEquals(BINARY_B64, v.asJsonObject().getString("k"));
+    }
+
+    @Test
+    public void testBinaryAsArrayValue() throws Exception
+    {
+        JsonValue v = MAPPER.convertValue(Collections.singletonList(BINARY), JsonValue.class);
+        assertEquals(JsonValue.ValueType.ARRAY, v.getValueType());
+        assertEquals(BINARY_B64, v.asJsonArray().getString(0));
+    }
+
+    @Test
+    public void testBinaryInArrayWithinObject() throws Exception
+    {
+        JsonValue v = MAPPER.convertValue(
+                Collections.singletonMap("k", Collections.singletonList(BINARY)),
+                JsonValue.class);
+        assertEquals(BINARY_B64, v.asJsonObject().getJsonArray("k").getString(0));
+    }
+
+    @Test
+    public void testBinaryInObjectWithinArray() throws Exception
+    {
+        JsonValue v = MAPPER.convertValue(
+                Collections.singletonList(Collections.singletonMap("k", BINARY)),
+                JsonValue.class);
+        assertEquals(BINARY_B64, v.asJsonArray().getJsonObject(0).getString("k"));
+    }
+
+    // Also verify it works when the declared target is the Array type itself
+    @Test
+    public void testBinaryAsJsonArray() throws Exception
+    {
+        JsonArray a = MAPPER.convertValue(Collections.singletonList(BINARY), JsonArray.class);
+        assertEquals(1, a.size());
+        assertEquals(BINARY_B64, a.getString(0));
+    }
+}

--- a/jsr-353/src/main/java/tools/jackson/datatype/jsr353/JsonValueDeserializer.java
+++ b/jsr-353/src/main/java/tools/jackson/datatype/jsr353/JsonValueDeserializer.java
@@ -187,6 +187,16 @@ public class JsonValueDeserializer extends StdDeserializer<JsonValue>
                 case VALUE_STRING:
                     b.add(p.getString());
                     break;
+                case VALUE_EMBEDDED_OBJECT: {
+                    // 09-Sep-2026, pjfanning: as with Object values above, support
+                    //   binary data as Base64 encoded text
+                    Object ob = p.getEmbeddedObject();
+                    if (ob instanceof byte[]) {
+                        String b64 = ctxt.getBase64Variant().encode((byte[]) ob, false);
+                        b.add(b64);
+                        break;
+                    }
+                }
                 default:
                     return (JsonArray) ctxt.handleUnexpectedToken(getValueType(ctxt), p);
             }

--- a/jsr-353/src/test/java/tools/jackson/datatype/jsr353/EmbeddedBinaryTest.java
+++ b/jsr-353/src/test/java/tools/jackson/datatype/jsr353/EmbeddedBinaryTest.java
@@ -1,0 +1,69 @@
+package tools.jackson.datatype.jsr353;
+
+import java.util.Collections;
+
+import javax.json.*;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for binary (byte[]) content embedded in the token stream, which is
+ * exposed as Base64 encoded text (see [issue#5]). Verifies Array and Object
+ * positions behave the same way.
+ */
+public class EmbeddedBinaryTest extends TestBase
+{
+    private final ObjectMapper MAPPER = newMapper();
+
+    // 3 bytes that Base64-encode to "AQID"
+    private final static byte[] BINARY = new byte[] { 1, 2, 3 };
+
+    private final static String BINARY_B64 = "AQID";
+
+    @Test
+    public void testBinaryAsObjectValue() throws Exception
+    {
+        JsonValue v = MAPPER.convertValue(Collections.singletonMap("k", BINARY), JsonValue.class);
+        assertEquals(JsonValue.ValueType.OBJECT, v.getValueType());
+        assertEquals(BINARY_B64, v.asJsonObject().getString("k"));
+    }
+
+    @Test
+    public void testBinaryAsArrayValue() throws Exception
+    {
+        JsonValue v = MAPPER.convertValue(Collections.singletonList(BINARY), JsonValue.class);
+        assertEquals(JsonValue.ValueType.ARRAY, v.getValueType());
+        assertEquals(BINARY_B64, v.asJsonArray().getString(0));
+    }
+
+    @Test
+    public void testBinaryInArrayWithinObject() throws Exception
+    {
+        JsonValue v = MAPPER.convertValue(
+                Collections.singletonMap("k", Collections.singletonList(BINARY)),
+                JsonValue.class);
+        assertEquals(BINARY_B64, v.asJsonObject().getJsonArray("k").getString(0));
+    }
+
+    @Test
+    public void testBinaryInObjectWithinArray() throws Exception
+    {
+        JsonValue v = MAPPER.convertValue(
+                Collections.singletonList(Collections.singletonMap("k", BINARY)),
+                JsonValue.class);
+        assertEquals(BINARY_B64, v.asJsonArray().getJsonObject(0).getString("k"));
+    }
+
+    // Also verify it works when the declared target is the Array type itself
+    @Test
+    public void testBinaryAsJsonArray() throws Exception
+    {
+        JsonArray a = MAPPER.convertValue(Collections.singletonList(BINARY), JsonArray.class);
+        assertEquals(1, a.size());
+        assertEquals(BINARY_B64, a.getString(0));
+    }
+}

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -15,7 +15,8 @@ Modules:
 
 3.3.0 (not yet released)
 
-No changes since 3.2
+#96: (jsonp,jsr-353) Embedded binary (`byte[]`) not supported as Array value,
+  only as Object value
 
 3.2.2 (14-Aug-2026)
 


### PR DESCRIPTION
### Problem

The #5 handling that exposes embedded `byte[]` as Base64 text was added to `_deserializeObject()` but never to `_deserializeArray()`. The same binary value therefore succeeds or fails purely by position:

```
{"k": <byte[]>}  ->  {"k":"AQID"}
[ <byte[]> ]     ->  MismatchedInputException: Cannot deserialize value of type
                     `jakarta.json.JsonValue` from Embedded Object value
```

Reproduced with `MAPPER.convertValue(Collections.singletonList(bytes), JsonValue.class)`, and it applies to any `VALUE_EMBEDDED_OBJECT` reaching an Array — binary formats, `TokenBuffer`, `convertValue`.

### Fix

Add the matching `VALUE_EMBEDDED_OBJECT` case to the Array path, including the same fall-through to `handleUnexpectedToken()` for embedded values that are not `byte[]`. Applied to **both** `jakarta-jsonp` and `jsr-353` so the twin modules do not drift again (cf. #92).

Root-level embedded values are deliberately left alone — `_deserializeScalar()` still reports them as unexpected, carrying its existing `// Not sure what to do with it` note. That is a separate design question from the Array/Object inconsistency fixed here; happy to fold it in if you want root-level `byte[]` to become a `JsonString` too.

### Tests

New `EmbeddedBinaryTest` in both modules (5 cases): binary as an Object value, as an Array value, nested each way, and with `JsonArray` as the declared target.

`jakarta-jsonp` suite: 28 tests, all green.