### PR TITLE
(jsr-353) Re-enable test suite by running tests from class path

### DIFF
--- a/jsr-353/pom.xml
+++ b/jsr-353/pom.xml
@@ -38,28 +38,30 @@ working with JSR-353 (JSON-P) node types via data-binding
     <!-- 18-Jan-2025, tatu: Except, not with JPMS because that PoS component
        decided to use Automatic Module Name of "java.json". Which it absolutely
        cannot, being the _API_ module.
-       So. We cannot really run tests any more. And with deprecation by Jakarta JSONP
-       we may want to remove the module. But for now drop dep
+       09-Sep-2026, pjfanning: worked around by running tests from class path
+       (see `useModulePath` below), so the clashing module name is never read.
+      -->
     <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>javax.json</artifactId>
         <version>1.1.4</version>
         <scope>test</scope>
     </dependency>
-      -->
 
   </dependencies>
 
   <build>
     <plugins>
-      <!-- 18-Jan-2025, tatu: As per above, we cannot really run tests with JPMS.
-              So. Disable surefire plug-in altogether
+      <!-- 09-Sep-2026, pjfanning: The JSON-P 1.1 RI declares Automatic-Module-Name
+              "java.json", the same name as the API module, so the two cannot both be
+              read on the module path. Run tests from the class path instead, where
+              module names are not used: that lets the suite run again.
         -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <skipTests>true</skipTests>
+          <useModulePath>false</useModulePath>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
### Problem

`jsr-353` has had `<skipTests>true</skipTests>` since 18-Jan-2025. The reason is recorded in the pom: the JSON-P 1.1 RI (`org.glassfish:javax.json`) declares `Automatic-Module-Name: java.json`, the *same* name as the API module (`javax.json:javax.json-api`), so both cannot be read on the module path. With the RI dropped, every test errors at class-init:

```
javax.json.JsonException: Provider org.glassfish.json.JsonProviderImpl not found
	at java.json/javax.json.spi.JsonProvider.provider(JsonProvider.java:99)
	at tools.jackson.datatype.jsr353.JSR353Module.<init>(JSR353Module.java:25)
```

So the module has shipped with **zero** executed tests for over a year. That is how the `JsonPatch` START_ARRAY guard could sit here with tests that never ran while its jakarta twin silently lacked the fix (#92).

### Fix

The clashing Automatic-Module-Name only matters *on the module path*. Run the tests from the class path instead:

```xml
<plugin>
  <artifactId>maven-surefire-plugin</artifactId>
  <configuration>
    <useModulePath>false</useModulePath>
  </configuration>
</plugin>
```

and restore the test-scoped `org.glassfish:javax.json` dependency.

Main sources are still compiled on the module path, so `module-info.java`'s `requires java.json` is still validated — this only changes how tests execute.

### Result

26 tests run and pass, where 0 ran before:

```
[INFO] Running tools.jackson.datatype.jsr353.JsonPatchDeserializationTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
...
[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`mvn verify` on the module also passes: jar builds, SBOM generates. One benign warning remains during test compilation, which is exactly the collision being side-stepped:

```
[WARNING] Can't extract module name from javax.json-1.1.4.jar: Module 'java.json' is already on the module path!
```

Full reactor is green (jsr-353 26, joda-money 95, json-org 12, jakarta-jsonp 23, jakarta-mail 7, javax-money 135, moneta 137).

If you would rather retire the module than maintain it, that is obviously a fine outcome too — but while it ships, having the suite actually run seems worth it.